### PR TITLE
fix(product-service): add sort to fix FindAll test

### DIFF
--- a/src/product-service/products/demo_repository_test.go
+++ b/src/product-service/products/demo_repository_test.go
@@ -3,6 +3,7 @@ package products
 import (
 	"hsfl.de/group6/hsfl-master-ai-cloud-engineering/product-service/products/model"
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -92,6 +93,9 @@ func TestDemoRepository_FindAll(t *testing.T) {
 	for i, tt := range productTests {
 		t.Run("Is fetched product matching with "+tt.name+" added product?", func(t *testing.T) {
 			fetchedProducts, _ := demoRepository.FindAll()
+			sort.Slice(fetchedProducts, func(i, j int) bool {
+				return fetchedProducts[i].Id < fetchedProducts[j].Id
+			})
 			if !reflect.DeepEqual(tt.want, fetchedProducts[i]) {
 				t.Error("Fetched product does not match original product")
 			}


### PR DESCRIPTION
Fixed FindAll by adding a sort before the check (Maps in Go do not guarantee the order of iteration. Each time you range over the map, the order of elements may change).