### PR TITLE
feat(product-service): add getByEan for Products, update dependent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Price Whisper
-![Coverage](https://img.shields.io/badge/Coverage-83.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-83.7%25-brightgreen)
 [![Run tests (http proxy service)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-http-proxy-service.yml/badge.svg)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-http-proxy-service.yml)
 [![Run tests (product-service)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-product-service.yml/badge.svg)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-product-service.yml)
 [![Run tests (shoppinglist-service)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-shoppinglist-service.yml/badge.svg)](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/actions/workflows/run-tests-shoppinglist-service.yml)

--- a/src/product-service/api/router/router.go
+++ b/src/product-service/api/router/router.go
@@ -15,7 +15,8 @@ func New(productController products.Controller, pricesController prices.Controll
 	r := router.New()
 
 	r.GET("/api/v1/product/", productController.GetProducts)
-	r.GET("/api/v1/product/:productId", productController.GetProduct)
+	r.GET("/api/v1/product/ean/:productEan", productController.GetProductsByEan)
+	r.GET("/api/v1/product/:productId", productController.GetProductById)
 	r.PUT("/api/v1/product/:productId", productController.PutProduct)
 	r.POST("/api/v1/product/", productController.PostProduct)
 	r.DELETE("/api/v1/product/:productId", productController.DeleteProduct)

--- a/src/product-service/products/controller.go
+++ b/src/product-service/products/controller.go
@@ -14,7 +14,8 @@ type JsonFormatCreateProductRequest struct {
 
 type Controller interface {
 	GetProducts(http.ResponseWriter, *http.Request)
-	GetProduct(http.ResponseWriter, *http.Request)
+	GetProductsByEan(http.ResponseWriter, *http.Request)
+	GetProductById(http.ResponseWriter, *http.Request)
 	PostProduct(http.ResponseWriter, *http.Request)
 	PutProduct(http.ResponseWriter, *http.Request)
 	DeleteProduct(http.ResponseWriter, *http.Request)

--- a/src/product-service/products/default_controller.go
+++ b/src/product-service/products/default_controller.go
@@ -46,7 +46,7 @@ func (controller defaultController) PostProduct(writer http.ResponseWriter, requ
 	writer.WriteHeader(http.StatusCreated)
 }
 
-func (controller defaultController) GetProduct(writer http.ResponseWriter, request *http.Request) {
+func (controller defaultController) GetProductById(writer http.ResponseWriter, request *http.Request) {
 	productId, err := strconv.ParseUint(request.Context().Value("productId").(string), 10, 64)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
@@ -66,6 +66,30 @@ func (controller defaultController) GetProduct(writer http.ResponseWriter, reque
 	err = json.NewEncoder(writer).Encode(value)
 	if err != nil {
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (controller defaultController) GetProductsByEan(writer http.ResponseWriter, request *http.Request) {
+	productEan, err := strconv.ParseUint(request.Context().Value("productEan").(string), 10, 64)
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	values, err := controller.productRepository.FindByEan(productEan)
+	if err != nil {
+		if err.Error() == ErrorProductNotFound {
+			http.Error(writer, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(values)
+	if err != nil {
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/src/product-service/products/demo_repository.go
+++ b/src/product-service/products/demo_repository.go
@@ -61,6 +61,19 @@ func (repo *DemoRepository) FindById(id uint64) (*model.Product, error) {
 	return nil, errors.New(ErrorProductNotFound)
 }
 
+func (repo *DemoRepository) FindByEan(ean uint64) ([]*model.Product, error) {
+	var entries []*model.Product
+	for _, entry := range repo.products {
+		if entry.Ean == ean {
+			entries = append(entries, entry)
+		}
+	}
+	if len(entries) == 0 {
+		return nil, errors.New(ErrorProductNotFound)
+	}
+	return entries, nil
+}
+
 func (repo *DemoRepository) Update(product *model.Product) (*model.Product, error) {
 	existingProduct, foundError := repo.FindById(product.Id)
 

--- a/src/product-service/products/demo_repository_test.go
+++ b/src/product-service/products/demo_repository_test.go
@@ -140,6 +140,43 @@ func TestDemoRepository_FindById(t *testing.T) {
 	})
 }
 
+func TestDemoRepository_FindByEan(t *testing.T) {
+	// Prepare test
+	demoRepository := NewDemoRepository()
+
+	product := model.Product{
+		Id:          1,
+		Description: "Strauchtomaten",
+		Ean:         4014819040771,
+	}
+
+	_, err := demoRepository.Create(&product)
+	if err != nil {
+		t.Fatal("Failed to add prepare product for test")
+	}
+
+	t.Run("Fetch product with existing ean", func(t *testing.T) {
+		_, err := demoRepository.FindByEan(product.Ean)
+		if err != nil {
+			t.Errorf("Can't find expected product with ean %d", product.Ean)
+		}
+
+		t.Run("Is fetched product matching with added product?", func(t *testing.T) {
+			fetchedProduct, _ := demoRepository.FindByEan(product.Ean)
+			if !reflect.DeepEqual(product, *fetchedProduct[0]) {
+				t.Error("Fetched product does not match original product")
+			}
+		})
+	})
+
+	t.Run("Non-existing product test", func(t *testing.T) {
+		_, err = demoRepository.FindByEan(42)
+		if err.Error() != ErrorProductNotFound {
+			t.Error(err)
+		}
+	})
+}
+
 func TestDemoRepository_Update(t *testing.T) {
 	// Prepare test
 	demoRepository := NewDemoRepository()

--- a/src/product-service/products/repository.go
+++ b/src/product-service/products/repository.go
@@ -9,6 +9,7 @@ type Repository interface {
 	Delete(*model.Product) error
 	FindAll() ([]*model.Product, error)
 	FindById(id uint64) (*model.Product, error)
+	FindByEan(id uint64) ([]*model.Product, error)
 	Update(*model.Product) (*model.Product, error)
 }
 


### PR DESCRIPTION
Please check this thoroughly.

Because we only had 1 GET Route for the products (the one for the id) i added another one and renamed the id one. Now there's:
- r.GET("/api/v1/product/id/:productId", productController.GetProductById)
and
- r.GET("/api/v1/product/ean/:productEan", productController.GetProductsByEan)

Because the route of the product changed, when you want to get a product using the id, the method in the frontend of "ShoppingListEntry.svelte" needs an updated "apiUrlProduct". I made this change locally, and it is pushed, but trying any of the docker-compose-files that use the load-balancer will produce a faulty frontend, because it uses the image from docker hub, which is 6 days old and the details of the products get fetched incorrectly, because the route/url is now invalid (see attached picture below)

![image](https://github.com/Onyxmoon/hsfl-master-ai-cloud-engineering/assets/62237988/21e83c54-63f2-404c-aea5-1b0748664bb3)

But testing the changes locally using the docker-compose.dev.native.yml renders the frontend correctly.
Closes #90
